### PR TITLE
player名と勝率を追加実装

### DIFF
--- a/server/controller.js
+++ b/server/controller.js
@@ -24,16 +24,8 @@ const handlePostPlay = function(req, res) {
 };
 
 const handleFetchLeaderboard = function(req, res) {
-  //
-  // TODO
-  //
-  res.json([{
-    name: 'Not a real player',
-    wins: 1000,
-    losses: 0,
-    ties: 0,
-    winPercentage: '100.00',
-  }]);
+  const leadersArray = leaderboard.getLeaderBoard();
+  res.json(leadersArray);
 };
 
 module.exports = {

--- a/server/model/Leaderboard.js
+++ b/server/model/Leaderboard.js
@@ -3,32 +3,21 @@ const Player = require('./Player');
 class Leaderboard {
   constructor() {
     this.leadersArray = [];
-
-    // this.leadersArray に含まれているインスタンスの取得が効率よくできるために
-    // this.leadersMap はこんなキー・バリュー型で格納するのがいい：
-    // {
-    //   名前： player インスタンス
-    // }
     this.leadersMap = {};
   }
 
-  // winStatus will be 1, 0, or -1
   updateLeaderBoard({ name, winStatus }) {
-    //
-    // TODO - リーダーボード配列を更新しよう
-    // name      STRING: player name
-    // winStatus NUMBER: lose (-1), tie (0), win (1)
-    //
-    // 注意：各playerの勝率を使用してthis.leadersArrayの並び替えを忘れないように！
-    //
-    // 大事なポイント： Player.js も開いて、player インスタンスが何をできるかをざっと見とこう。
-    //
     let player;
     if (this.doesPlayerExist(name)) {
       player = this.leadersMap[name];
+      player.updateStats(winStatus);
     } else {
       player = new Player(name);
+      player.updateStats(winStatus);
+      this.leadersMap[name] = player;
+      this.leadersArray.push(player);
     }
+    this.leadersArray.sort(this.getWinningPercentage);
   }
 
   getLeaderBoard() {
@@ -41,6 +30,10 @@ class Leaderboard {
 
   getPlayerStats(name) {
     return this.leadersMap[name].getStats();
+  }
+
+  getWinningPercentage(player) {
+    return player.winPercentage;
   }
 }
 

--- a/server/model/Leaderboard.js
+++ b/server/model/Leaderboard.js
@@ -32,8 +32,8 @@ class Leaderboard {
     return this.leadersMap[name].getStats();
   }
 
-  getWinningPercentage(player) {
-    return player.winPercentage;
+  getWinningPercentage(player, secondPlayer) {
+    return secondPlayer.winPercentage - player.winPercentage;
   }
 }
 


### PR DESCRIPTION
# 実装
- player名が表示されるように実装
- 勝率がdefaultだと1000%になっているので、リアルタイムで反映されるように修正

# イメージ
<img width="711" alt="2018-10-10 11 20 26" src="https://user-images.githubusercontent.com/34594829/46709390-82f77080-cc7e-11e8-9ab0-ffa01179edcb.png">
